### PR TITLE
Create style-properties.html

### DIFF
--- a/guidelines/terms/21/style-properties.html
+++ b/guidelines/terms/21/style-properties.html
@@ -1,0 +1,12 @@
+<dt class="proposed"><dfn>Style Properties</dfn></dt>
+  <dd class="proposed">
+  <p class="change">Proposed</p>
+  <p>Properties whose values determine the presentation (e.g. font, color, size, location, padding, volume, synthesized speech prosody) of
+ content elements as they are rendered (e.g. onscreen, via loudspeaker,  via braille display) by user agents. Style properties can have several origins:</p>
+    <ul>
+      <li>user agent default styles: The default style property values applied in the absence of any author or user styles. Some web content technologies specify a default rendering; others do not.</li>
+      <li>author styles: Style property values that are set by the author as part of the content (e.g. in-line styles, author style
+sheets).</li>
+      <li>user styles: Style property values that are set by the user (e.g. via user agent interface settings, user style sheets).</li>
+    </ul>
+</dd>


### PR DESCRIPTION
Adding  a "Style Properties" definition for the adapting text SC (Issue 78).
It is  taken from UAAG: 
[https://www.w3.org/TR/UAAG20-Reference/#def-style-properties](https://www.w3.org/TR/UAAG20-Reference/#def-style-properties)